### PR TITLE
Fix broken symlinks in ncbi-rmblastn

### DIFF
--- a/vc3-builder
+++ b/vc3-builder
@@ -16802,7 +16802,7 @@ __DATA__
                             "mkdir -p ${VC3_PREFIX}",
                             "tar -C ${VC3_PREFIX} --strip-components=1 -xpf ncbi-rmblastn-2.2.28-x64-linux.tar.gz",
                             "cd ${VC3_PREFIX}/bin",
-                            "for file in $VC3_ROOT_NCBI_BLAST/bin/*; do ln -s ../../${file#${VC3_ROOT}/${VC3_MACHINE_TARGET}/}; done"
+                            "for file in $VC3_ROOT_NCBI_BLAST/bin/*; do ln -s ../../../${file#${VC3_ROOT}/${VC3_MACHINE_TARGET}/}; done"
                         ]
                     },
                     {

--- a/vc3-catalog.json
+++ b/vc3-catalog.json
@@ -2977,7 +2977,7 @@
                             "mkdir -p ${VC3_PREFIX}",
                             "tar -C ${VC3_PREFIX} --strip-components=1 -xpf ncbi-rmblastn-2.2.28-x64-linux.tar.gz",
                             "cd ${VC3_PREFIX}/bin",
-                            "for file in $VC3_ROOT_NCBI_BLAST/bin/*; do ln -s ../../${file#${VC3_ROOT}/${VC3_MACHINE_TARGET}/}; done"
+                            "for file in $VC3_ROOT_NCBI_BLAST/bin/*; do ln -s ../../../${file#${VC3_ROOT}/${VC3_MACHINE_TARGET}/}; done"
                         ]
                     },
                     {


### PR DESCRIPTION
The MAKER example wouldn't run, and it looks like some broken symlinks are to blame. I *think* this should fix things. I can run the example with these changes. @btovar this resolves the error I emailed about.